### PR TITLE
Built in escaping of xml tag contents.

### DIFF
--- a/src/soap.lua
+++ b/src/soap.lua
@@ -49,6 +49,36 @@ local function attrs (a)
 end
 
 ---------------------------------------------------------------------
+-- Escape xml escape characters in a string
+-- @param text String to escape characters in.
+-- @return String with escape characters replaced with escape codes.
+---------------------------------------------------------------------
+function escape(text)
+	local escaped_text = text:gsub('&', '&amp;')
+	escaped_text = escaped_text:gsub("'", '&apos;')
+	escaped_text = escaped_text:gsub('"', '&quot;')
+	escaped_text = escaped_text:gsub('>', '&gt;')
+	escaped_text = escaped_text:gsub('<', '&lt;')
+	
+	return escaped_text
+end
+
+---------------------------------------------------------------------
+-- Unescape xml unescape characters in a string
+-- @param text String to unescape characters in.
+-- @return String with escape codes replaced with escape characters.
+---------------------------------------------------------------------
+function unescape(text)
+	local unescaped_text = text:gsub('&amp;', '&')
+	unescaped_text = unescaped_text:gsub('&apos;', "'")
+	unescaped_text = unescaped_text:gsub('&quot;', '"')
+	unescaped_text = unescaped_text:gsub('&gt;', '>')
+	unescaped_text = unescaped_text:gsub('&lt;', '<')
+		
+	return unescaped_text
+end
+
+---------------------------------------------------------------------
 -- Serialize the children of an object.
 -- @param obj Table with the object to be serialized.
 -- @return String representation of the children.
@@ -72,7 +102,11 @@ end
 ---------------------------------------------------------------------
 serialize = function (obj)
 	local tt = type(obj)
-	if tt == "string" or tt == "number" then
+	if tt == "string" then
+		obj = unescape(obj)
+		obj = escape(obj)
+		return obj
+	elseif tt == "number" then
 		return obj
 	elseif tt == "table" then
 		local t = obj.tag

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -220,16 +220,13 @@ local tests = {
 </soap:Envelope>]]
 },
 
-local escape1 = "<this should be escaped>"
-local escape2 = '"this should also be &escaped"'
-escape1 = escape1:gsub("<", "&lt;"):gsub(">", "&gt;")
-escape2 = escape2:gsub("&", "&amp;"):gsub('"', "&quot;")
 {
 	namespace = nil,
 	method = "StringEscapingTest",
 	entries = {
-		{ tag = "string", escape1, },
-		{ tag = "string", escape2, },
+		{ tag = "string", "<this should be escaped>", },
+		{ tag = "string", '"this should also be &escaped"', },
+		{ tag = "string", 'do not re-escape my &amp;', },
 	},
 	xml = [[
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
@@ -237,13 +234,17 @@ escape2 = escape2:gsub("&", "&amp;"):gsub('"', "&quot;")
 		<StringEscapingTest>
 			<string>&lt;this should be escaped&gt;</string>
 			<string>&quot;this should also be &amp;escaped&quot;</string>
+			<string>do not re-escape my &amp;</string>
 		</StringEscapingTest>
 	</soap:Body>
 </soap:Envelope>]]
 },
 
 }
-
+local escape1 = "<this should be escaped>"
+local escape2 = '"this should also be &escaped"'
+escape1 = escape1:gsub("<", "&lt;"):gsub(">", "&gt;")
+escape2 = escape2:gsub("&", "&amp;"):gsub('"', "&quot;")
 for i, t in ipairs(tests) do
 	io.write(i..": "); io.flush()
 	local s = soap.encode (t)


### PR DESCRIPTION
This patch includes an update that builds in escaping of special characters passed in as contents of xml tags without re-escaping & in escape codes.  This change should work fine for people already escaping their xml tag contents and will escape them when not already escaped.

I don't know if you would be interested in this change or not but since it is backwards compatible with people who have already escaped their strings I figured it might be worth offering.
