### PR TITLE
Don't mess with args in the encode function

### DIFF
--- a/src/soap.lua
+++ b/src/soap.lua
@@ -177,9 +177,10 @@ local function encode (args)
 		envelope_template.attr["xmlns:soap"] = xmlns_soap
 	end
 	local xmlns = "xmlns"
+	local method = args.method
 	if args.internal_namespace then
 		xmlns = xmlns..":"..args.internal_namespace
-		args.method = args.internal_namespace..":"..args.method
+		method = args.internal_namespace..":"..method
 	end
 	-- Cleans old header and insert a new one (if it exists).
 	insert_header (envelope_template, args.header)
@@ -189,7 +190,7 @@ local function encode (args)
 		body[i] = args.entries[i]
 	end
 	-- Sets method (actually, the table's tag) and namespace.
-	body.tag = args.method
+	body.tag = method
 	body.attr[xmlns] = args.namespace
 	return serialize (envelope_template)
 end


### PR DESCRIPTION
This fixes a bug in the encode function which changes the content of the 'method' field (prepending the internal_namespace value). This prevents multiple calls to encode with the same args table. You may want this if you want to e.g. call 'encode' on the table and log the output, then pass the table to 'client.call'.