### PR TITLE
Leuwer 20171121 - Extend luasoap to use http-digest for digest authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # $Id: Makefile,v 1.13 2009/07/22 19:02:46 tomas Exp $
 #
 
-VERSION=3.0
-
-LUA_DIR= /usr/local/share/lua/5.1
+VERSION=4.0
+LUAV=5.2
+LUA_DIR= /usr/local/share/lua/$(LUAV)
 INSTALL_DIR= $(LUA_DIR)/soap
 EXTRA_DIR= $(INSTALL_DIR)/client
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,5 @@ uninstall:
 dist:
 	ln -fs `pwd` ../luasoap-$(VERSION)
 	cd .. && tar czf luasoap-$(VERSION).tar.gz  --exclude .git --exclude rockspecs luasoap-$(VERSION)/*
-#	cd ..; tar czf luasoap-$(VERSION).tar.gz luasoap-$(VERSION) --exclude .git --exclude rockspecs
 	rm -rf ../luasoap-$(VERSION)
 	echo Created ../luasoap-$(VERSION).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,8 @@ uninstall:
 	rm -rf $(INSTALL_DIR) $(LUA_DIR)/soap.lua
 
 dist:
-	cd ..; tar czf luasoap-$(VERSION).tar.gz luasoap-$(VERSION) --exclude .git --exclude rockspecs
+	ln -fs `pwd` ../luasoap-$(VERSION)
+	cd .. && tar czf luasoap-$(VERSION).tar.gz  --exclude .git --exclude rockspecs luasoap-$(VERSION)/*
+#	cd ..; tar czf luasoap-$(VERSION).tar.gz luasoap-$(VERSION) --exclude .git --exclude rockspecs
+	rm -rf ../luasoap-$(VERSION)
 	echo Created ../luasoap-$(VERSION).tar.gz

--- a/rockspecs/luasoap-4.0.0-0.rockspec
+++ b/rockspecs/luasoap-4.0.0-0.rockspec
@@ -1,0 +1,32 @@
+package = "luasoap"
+version = "4.0.0-0"
+
+source = {
+   url="https://github.com/tomasguisasola/luasoap/archive/v4_0_0.tar.gz",
+   md5="8ae6cde5eaeef469672946d1fc2e08bd"
+   dir="luasoap-4_0_0",
+}
+
+description = {
+   summary = "Support for SOAP",
+   detailed = "LuaSOAP provides a very simple API that convert Lua tables to and from XML documents",
+   homepage = "http://tomasguisasola.github.io/luasoap/",
+   license = "MIT/X11",
+}
+
+dependencies = {
+   "lua >= 5.0",
+   "luaexpat >= 1.1.0-3",
+   "luasocket >= 2.0.2-1",
+   "lua-http-digest >= 1.2.2-1"
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      soap  = "src/soap.lua",
+      ["soap.server"] = "src/server.lua",
+      ["soap.client"] = "src/client.lua",
+   }
+}
+


### PR DESCRIPTION
I extended luasoap such that it is able to perform SOAP access to a server via a digest authentication boundary.
The modified client introduces a new parameter component "auth" defining which authentication method to use:
- auth not set or auth = "basic" => use basic authentication that comes with socket.http
- auth = digest => load http-digest instead of socket.http for digest authenticaiton
In both cases the credentials are given in the URL as user info:
http://user:password@HOST/URL